### PR TITLE
Use standard format for license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2019-2021 Clark Winkelmann
-Emoji list Copyright (c) 2018 David Sevilla Martín
+Copyright (c) 2018 David Sevilla Martín
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/resources/emojis/LICENSE
+++ b/resources/emojis/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2021 Clark Winkelmann
+Copyright (c) 2018 David Sevilla Martín
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This will fix license detection on GitHub. Right now GitHub is not able to detect license of this repo.

Before:
![785b7529](https://user-images.githubusercontent.com/5972388/125204225-829bc200-e27c-11eb-92a5-f0e045115914.png)

After: 
![c423aa55](https://user-images.githubusercontent.com/5972388/125204228-87f90c80-e27c-11eb-9122-3ca98b270aad.png)

